### PR TITLE
Fix hello world C++ example

### DIFF
--- a/helloworld.cpp
+++ b/helloworld.cpp
@@ -1,9 +1,5 @@
-#include iostream;
-using namespace std;
-int main(){
-    cout << Hello world!;
-}#include iostream;
-using namespace std;
-int main(){
-    cout << Hello world!;
+#include <iostream>
+int main() {
+    std::cout << "Hello world!" << std::endl;
+    return 0;
 }


### PR DESCRIPTION
## Summary
- Avoid global namespace pollution by removing `using namespace std`

## Testing
- `g++ -std=c++17 helloworld.cpp -o helloworld`
- `./helloworld`


------
https://chatgpt.com/codex/tasks/task_e_689d646e8810832eb340eede67626d27